### PR TITLE
glTF import plugin preserves joint names

### DIFF
--- a/gltf/src/gltfImport.cpp
+++ b/gltf/src/gltfImport.cpp
@@ -1579,7 +1579,7 @@ importMeshes(ImportGltfContext& ctx)
 // Import skeletons from gltf.
 // First traverses all glTF nodes in the scene, to construct names appropriate for UsdSkel API
 // consumption (for the Skeleton::joints attribute), of the form:
-// n0/n1/n2...
+// rootJoint/childJoint1/childJoint2...
 // Then traverses all glTF skins and assembles skeleton data in the Usdata cache.
 // This doesn't specify instantiation of any skeletons, which is done by importNodes.
 // It's ok that importNodes runs before this one, because the skins and skeletons counts are
@@ -1591,7 +1591,7 @@ importSkeletons(ImportGltfContext& ctx)
     std::function<void(int parentIndex, int nodeIndex)> buildSkeletonNodeNames;
     buildSkeletonNodeNames = [&](int parentIndex, int nodeIndex) {
         const tinygltf::Node& node = ctx.gltf->nodes[nodeIndex];
-        std::string name = "n" + std::to_string(nodeIndex);
+        std::string name = node.name;
         ctx.skeletonNodeNames[nodeIndex] =
           parentIndex >= 0 ? ctx.skeletonNodeNames[parentIndex] + "/" + name : name;
         for (size_t i = 0; i < node.children.size(); i++) {


### PR DESCRIPTION


simply use the USD node name instead of creating new names

## Description

just use the available node name

## Related Issue

joint names where lost when importing glTF 

## Motivation and Context

needed for correctly importing

## How Has This Been Tested?

joint names are now correcly imported

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
