### PR TITLE
Switching to ninja generator

### DIFF
--- a/.github/workflows/create-usd-release.yml
+++ b/.github/workflows/create-usd-release.yml
@@ -112,6 +112,21 @@ jobs:
           brew uninstall --ignore-dependencies giflib
           brew cleanup
 
+      # OpenUSD's build_usd.py vendors zlib 1.2.13, which fails to compile
+      # under Clang 17 (Xcode 16.3+) due to a TARGET_OS_MAC macro bug
+      # (https://github.com/madler/zlib/issues/1076). macOS-15 and macos-26
+      # runners only ship Xcode versions past that threshold, so pre-seed a
+      # working zlib from Homebrew; build_usd.py skips building its own zlib
+      # if usd_build/include/zlib.h already exists.
+      - name: Install zlib via Homebrew (macOS-15 / macos-26)
+        if: env.exists == 'false' && (matrix.os == 'macOS-15' || matrix.os == 'macos-26')
+        run: |
+          brew install zlib
+          ZLIB_PREFIX=$(brew --prefix zlib)
+          mkdir -p "${{ github.workspace }}/usd_build/include" "${{ github.workspace }}/usd_build/lib"
+          cp -R "$ZLIB_PREFIX"/include/. "${{ github.workspace }}/usd_build/include/"
+          cp -P "$ZLIB_PREFIX"/lib/libz*.* "${{ github.workspace }}/usd_build/lib/"
+
       - name: Install Additional Dependencies (Ubuntu)
         if: env.exists == 'false' && runner.os == 'Linux'
         run: |

--- a/.github/workflows/create-usd-release.yml
+++ b/.github/workflows/create-usd-release.yml
@@ -167,6 +167,41 @@ jobs:
             -replace 'boostorg\.jfrog\.io/artifactory/main/release', 'archives.boost.io/release' `
             | Set-Content -Path $buildUsdPath
 
+      # Boost 1.78.0's bootstrap.bat auto-detects the compiler via
+      # `vswhere -latest`, which on the windows-2025 runner now resolves to a
+      # Visual Studio 18 (VS 2026) preview that its build engine doesn't know
+      # ("Unknown toolset: vcunk"), aborting the bootstrap. VS 2022 / v143 is
+      # also installed, and build_usd.py already builds Boost itself with
+      # toolset=msvc-14.3, so force bootstrap.bat's first positional argument
+      # (its toolset) to vc143 to match and bypass the broken auto-detection.
+      - name: Patch build_usd.py to force Boost bootstrap toolset (Windows)
+        if: env.exists == 'false' && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $buildUsdPath = "OpenUSD/build_scripts/build_usd.py"
+          (Get-Content -Path $buildUsdPath -Raw) `
+            -replace 'bootstrap = "bootstrap\.bat"', 'bootstrap = "bootstrap.bat vc143"' `
+            | Set-Content -Path $buildUsdPath
+
+      # USD 24.11's build_usd.py vendors libpng 1.6.38, whose pngpriv.h includes
+      # the Classic Mac OS <fp.h> header whenever TARGET_OS_MAC is defined and
+      # no <math.h> guard is set. The Xcode 26 / AppleClang 21 SDK on the
+      # macOS-15 and macos-26 runners defines TARGET_OS_MAC, so libpng tries to
+      # include <fp.h>, which no longer ships in the macOS SDK, failing the
+      # build (fatal error: 'fp.h' file not found). Defining __MATH_H__ (one of
+      # the guards libpng checks) makes it skip that include; it's harmless on
+      # clang, whose <math.h> uses a different guard. genout.cmake.in forwards
+      # CMAKE_C_FLAGS to its preprocessing step, so this reaches the failing
+      # intprefix.out generation. Append it to libpng's existing C flags.
+      - name: Patch build_usd.py to work around libpng fp.h include (macOS)
+        if: env.exists == 'false' && runner.os == 'macOS'
+        shell: pwsh
+        run: |
+          $buildUsdPath = "OpenUSD/build_scripts/build_usd.py"
+          (Get-Content -Path $buildUsdPath -Raw) `
+            -replace '-DPNG_ARM_NEON_OPT=0', '-DPNG_ARM_NEON_OPT=0 -D__MATH_H__' `
+            | Set-Content -Path $buildUsdPath
+
       - name: Set up MSVC Dev Environment
         if: env.exists == 'false' && runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/create-usd-release.yml
+++ b/.github/workflows/create-usd-release.yml
@@ -183,23 +183,33 @@ jobs:
             -replace 'bootstrap = "bootstrap\.bat"', 'bootstrap = "bootstrap.bat vc143"' `
             | Set-Content -Path $buildUsdPath
 
-      # USD 24.11's build_usd.py vendors libpng 1.6.38, whose pngpriv.h includes
-      # the Classic Mac OS <fp.h> header whenever TARGET_OS_MAC is defined and
-      # no <math.h> guard is set. The Xcode 26 / AppleClang 21 SDK on the
-      # macOS-15 and macos-26 runners defines TARGET_OS_MAC, so libpng tries to
-      # include <fp.h>, which no longer ships in the macOS SDK, failing the
-      # build (fatal error: 'fp.h' file not found). Defining __MATH_H__ (one of
-      # the guards libpng checks) makes it skip that include; it's harmless on
-      # clang, whose <math.h> uses a different guard. genout.cmake.in forwards
-      # CMAKE_C_FLAGS to its preprocessing step, so this reaches the failing
-      # intprefix.out generation. Append it to libpng's existing C flags.
+      # USD 24.11's build_usd.py vendors libpng 1.6.38, whose pngpriv.h picks its
+      # math header like this:
+      #     #if (...) || defined(TARGET_OS_MAC)
+      #     #  if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
+      #     #    include <fp.h>
+      #     #  endif
+      #     #else
+      #     #  include <math.h>
+      #     #endif
+      # The Xcode 26 / AppleClang 21 SDK on the macOS-15 and macos-26 runners
+      # defines TARGET_OS_MAC, so the outer branch is taken and the <math.h>
+      # else-branch is never reached. libpng then tries to include the Classic
+      # Mac OS <fp.h> header, which no longer ships in the SDK (fatal error:
+      # 'fp.h' file not found). As pngpriv.h's own comment notes, it only wants
+      # <fp.h> when <math.h> wasn't already included, so force-include <math.h>
+      # via CMAKE_C_FLAGS: that defines its guard (skipping the <fp.h> include)
+      # and supplies the math declarations (modf/floor/pow) that png.c needs.
+      # genout.cmake.in forwards CMAKE_C_FLAGS to its preprocessing step, so this
+      # also clears the earlier intprefix.out generation. Append to libpng's
+      # existing C flags.
       - name: Patch build_usd.py to work around libpng fp.h include (macOS)
         if: env.exists == 'false' && runner.os == 'macOS'
         shell: pwsh
         run: |
           $buildUsdPath = "OpenUSD/build_scripts/build_usd.py"
           (Get-Content -Path $buildUsdPath -Raw) `
-            -replace '-DPNG_ARM_NEON_OPT=0', '-DPNG_ARM_NEON_OPT=0 -D__MATH_H__' `
+            -replace '-DPNG_ARM_NEON_OPT=0', '-DPNG_ARM_NEON_OPT=0 -include math.h' `
             | Set-Content -Path $buildUsdPath
 
       - name: Set up MSVC Dev Environment

--- a/.github/workflows/create-usd-release.yml
+++ b/.github/workflows/create-usd-release.yml
@@ -11,6 +11,11 @@ on:
         required: true
         default: "2511"
 
+env:
+  # ilammy/msvc-dev-cmd has no Node 24 release; opt it (and any other
+  # holdouts) into Node 24 ahead of GitHub's June 2026 forced switch.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
@@ -88,8 +93,8 @@ jobs:
           python -m pip install --upgrade pip setuptools
           python -c "import ssl; print('SSL OK:', ssl.OPENSSL_VERSION)"
 
-      - name: Install Ninja (Unix)
-        if: env.exists == 'false' && matrix.os != 'windows-2022'
+      - name: Install Ninja
+        if: env.exists == 'false'
         run: |
           python -m pip install ninja
 
@@ -133,9 +138,13 @@ jobs:
             python -m pip install jinja2
           }
 
+      - name: Set up MSVC Dev Environment
+        if: env.exists == 'false' && runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
       # New Step: Patch build_usd.py to override IsVisualStudioVersionOrGreater
       - name: Patch build_usd.py to Always Return True on Windows
-        if: env.exists == 'false' && matrix.os == 'windows-2022'
+        if: env.exists == 'false' && runner.os == 'Windows'
         shell: pwsh
         run: |
           # Define the path to build_usd.py
@@ -177,12 +186,6 @@ jobs:
           $abi_arg = ""
           $generator = "--generator Ninja"
 
-          if ("${{runner.os}}" -eq "Windows") {
-            $generator = '--generator "Visual Studio 17 2022"'
-            $fileContent = Get-Content $file -Raw
-            $fileContent = $fileContent -replace ' -- \{multiproc\}', ''
-            Set-Content $file -Value $fileContent
-          }
           if ("${{runner.os}}" -eq "Linux") {
             $abi_arg = "--use-cxx11-abi 0"
           }

--- a/.github/workflows/create-usd-release.yml
+++ b/.github/workflows/create-usd-release.yml
@@ -167,21 +167,31 @@ jobs:
             -replace 'boostorg\.jfrog\.io/artifactory/main/release', 'archives.boost.io/release' `
             | Set-Content -Path $buildUsdPath
 
-      # Boost 1.78.0's bootstrap.bat auto-detects the compiler via
-      # `vswhere -latest`, which on the windows-2025 runner now resolves to a
-      # Visual Studio 18 (VS 2026) preview that its build engine doesn't know
-      # ("Unknown toolset: vcunk"), aborting the bootstrap. VS 2022 / v143 is
-      # also installed, and build_usd.py already builds Boost itself with
-      # toolset=msvc-14.3, so force bootstrap.bat's first positional argument
-      # (its toolset) to vc143 to match and bypass the broken auto-detection.
-      - name: Patch build_usd.py to force Boost bootstrap toolset (Windows)
+      # The windows-2025 runner ships both Visual Studio 2022 (v143) and a newer
+      # Visual Studio 18 (2026). Boost 1.78.0's toolset detection
+      # (tools/build/src/engine/vswhere_usability_wrapper.cmd) queries vswhere for
+      # "[18.0,19.0)" *first* and short-circuits on a match, so it finds VS 18,
+      # sets VSUNKCOMNTOOLS, and never sets VS170COMNTOOLS -- guess_toolset.bat
+      # then falls through to B2_TOOLSET=vcunk and bootstrap aborts with
+      # "Unknown toolset: vcunk". guess_toolset.bat checks VS170COMNTOOLS *before*
+      # VSUNKCOMNTOOLS, so pre-seeding it with the installed VS 2022 path makes
+      # Boost pick vc143 (the toolset windows-2022 already builds Boost with, and
+      # the one build_usd.py drives b2 with via toolset=msvc-14.3). Locate VS 2022
+      # via vswhere's version filter and export VS170COMNTOOLS for later steps.
+      - name: Point Boost at the VS 2022 (v143) toolset (Windows)
         if: env.exists == 'false' && runner.os == 'Windows'
         shell: pwsh
         run: |
-          $buildUsdPath = "OpenUSD/build_scripts/build_usd.py"
-          (Get-Content -Path $buildUsdPath -Raw) `
-            -replace 'bootstrap = "bootstrap\.bat"', 'bootstrap = "bootstrap.bat vc143"' `
-            | Set-Content -Path $buildUsdPath
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vs2022 = & $vswhere -version "[17.0,18.0)" -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+          if (-not $vs2022) {
+            Write-Error "Visual Studio 2022 (v143) not found on this runner."
+            exit 1
+          }
+          Write-Output "Using VS 2022 at: $vs2022"
+          "VS170COMNTOOLS=$vs2022\Common7\Tools\" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       # USD 24.11's build_usd.py vendors libpng 1.6.38, whose pngpriv.h picks its
       # math header like this:
@@ -212,9 +222,15 @@ jobs:
             -replace '-DPNG_ARM_NEON_OPT=0', '-DPNG_ARM_NEON_OPT=0 -include math.h' `
             | Set-Content -Path $buildUsdPath
 
+      # Pin to VS 2022 so the active compiler (cl.exe) is v143, matching both the
+      # VS170COMNTOOLS we seed for Boost above and the toolset=msvc-14.3 that
+      # build_usd.py drives b2 with. Without this, ilammy defaults to the newest
+      # VS (18 / 2026) on windows-2025, which USD 24.11's deps don't support.
       - name: Set up MSVC Dev Environment
         if: env.exists == 'false' && runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          vsversion: "2022"
 
       # New Step: Patch build_usd.py to override IsVisualStudioVersionOrGreater
       - name: Patch build_usd.py to Always Return True on Windows

--- a/.github/workflows/create-usd-release.yml
+++ b/.github/workflows/create-usd-release.yml
@@ -153,6 +153,20 @@ jobs:
             python -m pip install jinja2
           }
 
+      # boostorg.jfrog.io stopped serving release archives (it now returns
+      # JFrog's marketing landing page with HTTP 200), so build_usd.py's
+      # hardcoded BOOST_URL downloads succeed but produce an unparsable
+      # "archive", failing with "unrecognized archive file type". Repoint
+      # Boost downloads at archives.boost.io, the current official host.
+      - name: Patch build_usd.py to use a working Boost mirror
+        if: env.exists == 'false'
+        shell: pwsh
+        run: |
+          $buildUsdPath = "OpenUSD/build_scripts/build_usd.py"
+          (Get-Content -Path $buildUsdPath -Raw) `
+            -replace 'boostorg\.jfrog\.io/artifactory/main/release', 'archives.boost.io/release' `
+            | Set-Content -Path $buildUsdPath
+
       - name: Set up MSVC Dev Environment
         if: env.exists == 'false' && runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
## Description
As of mid June, Windows builders for github actions now default to visual studio 2026. Switching to ninja generator to hopefully resolve the issues that stem from this. 