### PR TITLE
Double Free Fix for 2026.07

### DIFF
--- a/fbx/tests/CMakeLists.txt
+++ b/fbx/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ PRIVATE
     GTest::gtest
     GTest::gtest_main
     fbxsdk::fbxsdk
-    fileformatUtils
+    fileformatUtilsTest
     gtestCommon
 )
 

--- a/gltf/tests/CMakeLists.txt
+++ b/gltf/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ PRIVATE
     usdShade
     GTest::gtest
     GTest::gtest_main
-    fileformatUtils
+    fileformatUtilsTest
     gtestCommon
     nlohmann_json::nlohmann_json
 )

--- a/obj/tests/CMakeLists.txt
+++ b/obj/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ PRIVATE
     usd
     GTest::gtest
     GTest::gtest_main
-    fileformatUtils
+    fileformatUtilsTest
     gtestCommon
 )
 

--- a/ply/tests/CMakeLists.txt
+++ b/ply/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ PRIVATE
     usd
     GTest::gtest
     GTest::gtest_main
-    fileformatUtils
+    fileformatUtilsTest
     gtestCommon
 )
 

--- a/spz/tests/CMakeLists.txt
+++ b/spz/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ PRIVATE
     usd
     GTest::gtest
     GTest::gtest_main
-    fileformatUtils
+    fileformatUtilsTest
     gtestCommon
 )
 

--- a/stl/tests/CMakeLists.txt
+++ b/stl/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ PRIVATE
     usd
     GTest::gtest
     GTest::gtest_main
-    fileformatUtils
+    fileformatUtilsTest
     gtestCommon
 )
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -138,16 +138,28 @@ if (USD_FILEFORMATS_ENABLE_PLY OR USD_FILEFORMATS_ENABLE_SPZ)
 endif()
 
 if(USD_FILEFORMATS_BUILD_TESTS)
-    target_sources(fileformatUtils
-        PRIVATE
-            "include/fileformatutils/test.h"
-            "src/test.cpp"
+    # Test-only helper (assertion utilities, openAssetStage, etc.). It is kept in a
+    # separate STATIC library rather than being folded into the SHARED fileformatUtils
+    # runtime library on purpose: GTest is statically linked, and embedding it in the
+    # shared library *and* in every test executable made GoogleTest's global flag
+    # objects be duplicated across modules and destroyed twice during static teardown
+    # ("double free or corruption (fasttop)" on Linux). Linking GTest only into the
+    # static helper (and the test executables) keeps a single set of those globals.
+    add_library(fileformatUtilsTest STATIC
+        "include/fileformatutils/test.h"
+        "src/test.cpp"
     )
-    target_link_libraries(fileformatUtils
+    usd_plugin_compile_config(fileformatUtilsTest)
+    target_include_directories(fileformatUtilsTest
         PUBLIC
-            GTest::gtest # should separate usdutils-runtime part and usdutils-test part
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     )
-    
+    target_link_libraries(fileformatUtilsTest
+        PUBLIC
+            fileformatUtils
+            GTest::gtest
+    )
+
     add_subdirectory(tests)
 endif()
 

--- a/utils/include/fileformatutils/test.h
+++ b/utils/include/fileformatutils/test.h
@@ -17,7 +17,14 @@ governing permissions and limitations under the License.
 /// These functions are as simple as they can be, and don't share code with the main body of code.
 ///
 
-#include "api.h"
+// test.h and its implementation (test.cpp) are built into the static, test-only
+// fileformatUtilsTest helper library and linked directly into each test executable.
+// Unlike the shared fileformatUtils runtime library, this helper needs no
+// import/export decoration, so USDFFUTILSTEST_API expands to nothing. Keeping it
+// out of the shared library is what prevents GoogleTest's global flag objects from
+// being duplicated across the executable and libfileformatUtils.so (which caused a
+// double free of those objects during static teardown on Linux).
+#define USDFFUTILSTEST_API
 
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/diagnosticMgr.h>
@@ -35,7 +42,7 @@ governing permissions and limitations under the License.
       surface)(UsdPreviewSurface)(useSpecularWorkflow)(diffuseColor)(emissiveColor)(specularColor)(normal)(metallic)(roughness)(clearcoat)(clearcoatRoughness)(opacity)(opacityThreshold)(displacement)(occlusion)(ior)
 
 PXR_NAMESPACE_OPEN_SCOPE
-TF_DECLARE_PUBLIC_TOKENS(TestTokens, USDFFUTILS_API, TEST_TOKENS);
+TF_DECLARE_PUBLIC_TOKENS(TestTokens, USDFFUTILSTEST_API, TEST_TOKENS);
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #define ASSERT_PRIM(...) ASSERT_TRUE(assertPrim(__VA_ARGS__))
@@ -63,21 +70,21 @@ PXR_NAMESPACE_CLOSE_SCOPE
 
 // XXX This duplication of structs is highly suspicious
 template<typename T>
-struct USDFFUTILS_API ArrayData
+struct USDFFUTILSTEST_API ArrayData
 {
     size_t size;
     PXR_NS::VtArray<T> values; // a subset of the expected array data
 };
 
 template<typename T>
-struct USDFFUTILS_API PrimvarData
+struct USDFFUTILSTEST_API PrimvarData
 {
     PXR_NS::TfToken interpolation;
     ArrayData<T> values;
     ArrayData<int> indices;
 };
 
-struct USDFFUTILS_API MeshData
+struct USDFFUTILSTEST_API MeshData
 {
     ArrayData<int> faceVertexCounts;
     ArrayData<int> faceVertexIndices;
@@ -90,12 +97,12 @@ struct USDFFUTILS_API MeshData
     PrimvarData<float> displayOpacity;
 };
 
-struct USDFFUTILS_API PointsData
+struct USDFFUTILSTEST_API PointsData
 {
     size_t pointsCount;
 };
 
-struct USDFFUTILS_API InputData
+struct USDFFUTILSTEST_API InputData
 {
     PXR_NS::VtValue value;
     int uvIndex;
@@ -111,7 +118,7 @@ struct USDFFUTILS_API InputData
     std::string file; // a relative path to the current binary dir
 };
 
-struct USDFFUTILS_API MaterialData
+struct USDFFUTILSTEST_API MaterialData
 {
     InputData useSpecularWorkflow;
     InputData diffuseColor;
@@ -131,14 +138,14 @@ struct USDFFUTILS_API MaterialData
     InputData anisotropyLevel;
 };
 
-struct USDFFUTILS_API AnimationData
+struct USDFFUTILSTEST_API AnimationData
 {
     std::map<float, PXR_NS::GfQuatf> orient;
     std::map<float, PXR_NS::GfVec3f> scale;
     std::map<float, PXR_NS::GfVec3d> translate;
 };
 
-struct USDFFUTILS_API CameraData
+struct USDFFUTILSTEST_API CameraData
 {
     PXR_NS::GfQuatf orient;
     PXR_NS::GfVec3f scale;
@@ -153,7 +160,7 @@ struct USDFFUTILS_API CameraData
     float verticalAperture;
 };
 
-struct USDFFUTILS_API LightData
+struct USDFFUTILSTEST_API LightData
 {
     // Light transformation data
     std::optional<PXR_NS::GfVec3d> translation;
@@ -172,23 +179,23 @@ struct USDFFUTILS_API LightData
     // ImageAsset texture
 };
 
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertPrim(PXR_NS::UsdStageRefPtr stage, const std::string& path);
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertNode(PXR_NS::UsdStageRefPtr stage, const std::string& path);
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertMesh(PXR_NS::UsdStageRefPtr stage, const std::string& path, const MeshData& data);
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertPoints(PXR_NS::UsdStageRefPtr stage, const std::string& path, const PointsData& data);
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertMaterial(PXR_NS::UsdStageRefPtr stage, const std::string& path, const MaterialData& data);
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertAnimation(PXR_NS::UsdStageRefPtr stage, const std::string& path, const AnimationData& data);
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertCamera(PXR_NS::UsdStageRefPtr stage, const std::string& path, const CameraData& data);
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertLight(PXR_NS::UsdStageRefPtr stage, const std::string& path, const LightData& data);
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertDisplayName(PXR_NS::UsdStageRefPtr stage,
                   const std::string& primPath,
                   const std::string& displayName);
@@ -202,28 +209,28 @@ assertDisplayName(PXR_NS::UsdStageRefPtr stage,
  * @param expectedActualVisibility If the prim is expected to be visible or invisible, when the
  * effective visibility is computed with UsdGeomImageable::ComputeVisibility()
  */
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertVisibility(PXR_NS::UsdStageRefPtr stage,
                  const std::string& path,
                  bool expectedVisibilityAttr,
                  bool expectedActualVisibility);
 
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertRender(const std::string& filename, const std::string& imageFilename);
 
 /// Compares a USD layer against a baseline USDA file.
 /// If generateBaseline is true, exports the layer to the baseline path instead of comparing.
 /// If dumpOnFailure is true, writes the actual output next to the baseline when comparison fails.
-[[nodiscard]] USDFFUTILS_API ::testing::AssertionResult
+[[nodiscard]] USDFFUTILSTEST_API ::testing::AssertionResult
 assertUsda(const PXR_NS::SdfLayerHandle& sdfLayer,
            const std::string& baselinePath,
            bool generateBaseline = false,
            bool dumpOnFailure = false);
 
-[[nodiscard]] USDFFUTILS_API PXR_NS::UsdStageRefPtr
+[[nodiscard]] USDFFUTILSTEST_API PXR_NS::UsdStageRefPtr
 openAssetStage(const std::string& path);
 
-[[nodiscard]] USDFFUTILS_API PXR_NS::UsdStageRefPtr
+[[nodiscard]] USDFFUTILSTEST_API PXR_NS::UsdStageRefPtr
 openAssetStage(const std::string& path, const std::string& formatArgs);
 
 template<class T>

--- a/utils/tests/CMakeLists.txt
+++ b/utils/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(utilsTests
                         usdShade
                         GTest::gtest
                         GTest::gtest_main
-                        fileformatUtils
+                        fileformatUtilsTest
 )
 
 add_test(NAME utilsTests


### PR DESCRIPTION
Fix double-free at test teardown by splitting GTest out of shared fileformatUtils

The *SanityTests binaries aborted at process exit on Linux with "double free or corruption (fasttop)". The tests themselves passed; the abort happened during static-destructor teardown (_dl_fini -> libfileformatUtils.so __cxa_finalize -> std::string dtor).

Root cause: GoogleTest is statically linked and was embedded into BOTH the shared libfileformatUtils.so (which compiled the test helper test.cpp and linked GTest::gtest PUBLIC) AND every test executable. GoogleTest's global command-line-flag std::strings therefore collapsed to a single address under the ELF flat namespace, but each module registered its own __cxa_atexit finalizer, so the one object's destructor ran twice -> double free. macOS (two-level namespace) and Windows were unaffected, which is why only the ubuntu-22.04 jobs failed.

Fix: move the test-only helper (test.cpp/test.h) into a new STATIC library fileformatUtilsTest that links GTest, and stop linking GTest into the shared fileformatUtils runtime library. GTest now lives only in the static helper and the test executables, so there is a single set of GTest globals per process and a single destructor. The test helper gets its own empty USDFFUTILSTEST_API macro since a static library linked directly into each executable needs no import/export decoration (this also keeps Windows /WX happy). All test targets that used the helper now link fileformatUtilsTest, which brings fileformatUtils in transitively.
